### PR TITLE
Add pause on input option for Autopot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@
 ### Fixed
 - On change profile not start threads anymore.
 - App don't crash anymore with a invalid json profile.
+
+## [v1.3.0] - 2025-05-10
+### Added
+- Autopot option to pause when another key is pressed, preventing hotkey conflicts

--- a/Forms/AutopotForm.Designer.cs
+++ b/Forms/AutopotForm.Designer.cs
@@ -41,6 +41,7 @@
             this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.txtSPpct = new System.Windows.Forms.NumericUpDown();
+            this.cbPauseOnInput = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.txtHPpct)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.picBoxSP)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.picBoxHP)).BeginInit();
@@ -167,7 +168,18 @@
             this.txtSPpct.Size = new System.Drawing.Size(44, 23);
             this.txtSPpct.TabIndex = 40;
             this.txtSPpct.ValueChanged += new System.EventHandler(this.txtSPpctTextChanged);
-            // 
+            //
+            // cbPauseOnInput
+            //
+            this.cbPauseOnInput.AutoSize = true;
+            this.cbPauseOnInput.Location = new System.Drawing.Point(106, 113);
+            this.cbPauseOnInput.Name = "cbPauseOnInput";
+            this.cbPauseOnInput.Size = new System.Drawing.Size(103, 17);
+            this.cbPauseOnInput.TabIndex = 47;
+            this.cbPauseOnInput.Text = "Pause on Input";
+            this.cbPauseOnInput.UseVisualStyleBackColor = true;
+            this.cbPauseOnInput.CheckedChanged += new System.EventHandler(this.cbPauseOnInputCheckedChanged);
+            //
             // AutopotForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -187,6 +199,7 @@
             this.Controls.Add(this.txtAutopotDelay);
             this.Controls.Add(this.picBoxSP);
             this.Controls.Add(this.picBoxHP);
+            this.Controls.Add(this.cbPauseOnInput);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "AutopotForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
@@ -214,5 +227,6 @@
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.NumericUpDown txtSPpct;
+        private System.Windows.Forms.CheckBox cbPauseOnInput;
     }
 }

--- a/Forms/AutopotForm.cs
+++ b/Forms/AutopotForm.cs
@@ -47,6 +47,7 @@ namespace _4RTools.Forms
             this.txtHPpct.Text = this.autopot.hpPercent.ToString();
             this.txtSPpct.Text = this.autopot.spPercent.ToString();
             this.txtAutopotDelay.Text = this.autopot.delay.ToString();
+            this.cbPauseOnInput.Checked = this.autopot.pauseOnInput;
 
 
             txtHpKey.KeyDown += new System.Windows.Forms.KeyEventHandler(FormUtils.OnKeyDown);
@@ -55,8 +56,7 @@ namespace _4RTools.Forms
             txtSPKey.KeyDown += new System.Windows.Forms.KeyEventHandler(FormUtils.OnKeyDown);
             txtSPKey.KeyPress += new KeyPressEventHandler(FormUtils.OnKeyPress);
             txtSPKey.TextChanged += new EventHandler(this.onSpTextChange);
-
-
+            cbPauseOnInput.CheckedChanged += new EventHandler(this.cbPauseOnInputCheckedChanged);
         }
 
         private void onHpTextChange(object sender, EventArgs e)
@@ -102,6 +102,12 @@ namespace _4RTools.Forms
                 ProfileSingleton.SetConfiguration(this.autopot);
             }
             catch (Exception) { }
+        }
+
+        private void cbPauseOnInputCheckedChanged(object sender, EventArgs e)
+        {
+            this.autopot.pauseOnInput = this.cbPauseOnInput.Checked;
+            ProfileSingleton.SetConfiguration(this.autopot);
         }
     }
 }

--- a/Model/Autopot.cs
+++ b/Model/Autopot.cs
@@ -21,6 +21,7 @@ namespace _4RTools.Model
         public int spPercent { get; set; }
         public int delay { get; set; } = 15;
         public int delayYgg { get; set; } = 50;
+        public bool pauseOnInput { get; set; } = false;
 
         public string actionName { get; set; }
         private _4RThread thread;
@@ -88,9 +89,23 @@ namespace _4RTools.Model
             Keys k = (Keys)Enum.Parse(typeof(Keys), key.ToString());
             if ((k != Keys.None) && !Keyboard.IsKeyDown(Key.LeftAlt) && !Keyboard.IsKeyDown(Key.RightAlt))
             {
+                if (this.pauseOnInput && IsAnyKeyPressed()) return;
+
                 Interop.PostMessage(ClientSingleton.GetClient().process.MainWindowHandle, Constants.WM_KEYDOWN_MSG_ID, k, 0); // keydown
                 Interop.PostMessage(ClientSingleton.GetClient().process.MainWindowHandle, Constants.WM_KEYUP_MSG_ID, k, 0); // keyup
             }
+        }
+
+        private bool IsAnyKeyPressed()
+        {
+            foreach (Key k in Enum.GetValues(typeof(Key)))
+            {
+                if (k != Key.None && Keyboard.IsKeyDown(k))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public void Stop()

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project was created using Visual Studio 2022, just open `4RTools.sln` in Vi
 ## Features
 - [x] ON/OFF Button (with shortcut key)
 - [x] Autopot
+- Pause on Input option to avoid blocking other hotkeys
 - [x] Autobuff status
 - [x] Manage Profiles
 - [x] AHK Spammer


### PR DESCRIPTION
## Summary
- allow Autopot to pause when any other key is held
- expose pause setting in AutopotForm
- document the new option in README and CHANGELOG

## Testing
- `dotnet build 4RTools.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c55b2d758832cac098eda7a676dae